### PR TITLE
fix(userDashboard): add alias for productMediaUrl include

### DIFF
--- a/Backend/src/api/v1/controllers/commonControllers/userDashboard/userDashboard.controller.js
+++ b/Backend/src/api/v1/controllers/commonControllers/userDashboard/userDashboard.controller.js
@@ -67,6 +67,7 @@ const getUserDashboardProducts = async (req, res) => {
           include: [
             {
               model: productMediaUrl,
+              as: "productMediaUrl",
               attributes: ["product_media_url"],
               where: { media_type: "image" },
               required: false,


### PR DESCRIPTION
- Include 'as' attribute in productMediaUrl association to ensure correct join in query